### PR TITLE
GPIO cleanup

### DIFF
--- a/13_lcd1602.py
+++ b/13_lcd1602.py
@@ -265,4 +265,8 @@ def loop():
 		sleep(2)
 
 if __name__ == '__main__':
-	loop()
+	try:
+		loop()
+	except KeyboardInterrupt:
+		import RPi.GPIO as GPIO
+		GPIO.cleanup()


### PR DESCRIPTION
If you terminate this script with a CTRL+C, it doesn't properly clean the GPIO: simply wrap the main loop in a try:except to avoid this
